### PR TITLE
Add "-recorder" option for latexmk

### DIFF
--- a/ptex2pdf-fmt.sh
+++ b/ptex2pdf-fmt.sh
@@ -83,6 +83,9 @@ while [ $I -lt ${#args[@]} ]; do
         -i )
             IGNORE_FMT=true
             ;;
+        -recorder )
+            OPTIONS_FOR_TEX="$OPTIONS_FOR_TEX -recorder"
+            ;;
         -- | -)
             I=$(($I+1))
             while [ $I -lt ${#args[@]} ]; do


### PR DESCRIPTION
By default, the "latexmk" adds the "-recorder" option to latex.

I have changed it to be inside "-ot" when "-recorder" is specified to
handle this.

Signed-off-by: Youhei SASAKI <uwabami@gfd-dennou.org>